### PR TITLE
BaseBottomSheetViewController 추가

### DIFF
--- a/FindTown/FindTown.xcodeproj/project.pbxproj
+++ b/FindTown/FindTown.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BC6EFB88293BD60300AB3332 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6EFB87293BD60300AB3332 /* BaseViewController.swift */; };
 		BC6EFB8B293BD83E00AB3332 /* BaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6EFB8A293BD83E00AB3332 /* BaseViewModel.swift */; };
 		BC6EFB8D293BD8AB00AB3332 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6EFB8C293BD8AB00AB3332 /* ViewModelType.swift */; };
+		BC9CAABC294B12B6002C0763 /* BaseBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9CAABB294B12B6002C0763 /* BaseBottomSheetViewController.swift */; };
 		F31A80C82949A5BB003B8A6E /* FindTownCore in Frameworks */ = {isa = PBXBuildFile; productRef = F31A80C72949A5BB003B8A6E /* FindTownCore */; };
 		F31A80CA2949A5BB003B8A6E /* FindTownNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = F31A80C92949A5BB003B8A6E /* FindTownNetwork */; };
 		F31A80CC2949A5BB003B8A6E /* FindTownUI in Frameworks */ = {isa = PBXBuildFile; productRef = F31A80CB2949A5BB003B8A6E /* FindTownUI */; };
@@ -48,6 +49,7 @@
 		BC6EFB87293BD60300AB3332 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BC6EFB8A293BD83E00AB3332 /* BaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewModel.swift; sourceTree = "<group>"; };
 		BC6EFB8C293BD8AB00AB3332 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
+		BC9CAABB294B12B6002C0763 /* BaseBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetViewController.swift; sourceTree = "<group>"; };
 		F31A80C32949A556003B8A6E /* FindTownUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FindTownUI; sourceTree = "<group>"; };
 		F31A80C42949A568003B8A6E /* FindTownCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FindTownCore; sourceTree = "<group>"; };
 		F31A80C52949A577003B8A6E /* FindTownNetwork */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FindTownNetwork; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 			isa = PBXGroup;
 			children = (
 				BC6EFB87293BD60300AB3332 /* BaseViewController.swift */,
+				BC9CAABB294B12B6002C0763 /* BaseBottomSheetViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				BC6EFB8B293BD83E00AB3332 /* BaseViewModel.swift in Sources */,
 				BC6EFB8D293BD8AB00AB3332 /* ViewModelType.swift in Sources */,
 				BC6EFB88293BD60300AB3332 /* BaseViewController.swift in Sources */,
+				BC9CAABC294B12B6002C0763 /* BaseBottomSheetViewController.swift in Sources */,
 				F3891E1F293B8393003CE8AD /* AppDelegate.swift in Sources */,
 				F3891E21293B8393003CE8AD /* SceneDelegate.swift in Sources */,
 			);

--- a/FindTown/FindTown/Presentation/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/FindTown/FindTown/Presentation/Common/ViewController/BaseBottomSheetViewController.swift
@@ -9,6 +9,11 @@ import UIKit
 
 class BaseBottomSheetViewController: BaseViewController {
     
+    enum BottomSheetStatus {
+        case show
+        case hide
+    }
+    
     private let bottomHeight: CGFloat = 360
     private var bottomSheetViewTopConstraint: NSLayoutConstraint!
     
@@ -45,7 +50,7 @@ class BaseBottomSheetViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        showBottomSheet()
+        setBottomSheetStatus(to: .show)
     }
     
     override func addView() {
@@ -97,42 +102,39 @@ class BaseBottomSheetViewController: BaseViewController {
         view.addGestureRecognizer(swipeGesture)
     }
     
-    private func showBottomSheet() {
+    private func setBottomSheetStatus(to status: BottomSheetStatus) {
         let safeAreaHeight: CGFloat = view.safeAreaLayoutGuide.layoutFrame.height
         let bottomPadding: CGFloat = view.safeAreaInsets.bottom
         
-        bottomSheetViewTopConstraint.constant = (safeAreaHeight + bottomPadding) - bottomHeight
-        
-        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
-            self.dimmedBackView.alpha = 0.5
-            self.view.layoutIfNeeded()
-        }, completion: nil)
-    }
-    
-    private func hideBottomSheet() {
-        let safeAreaHeight = view.safeAreaLayoutGuide.layoutFrame.height
-        let bottomPadding = view.safeAreaInsets.bottom
-        
-        bottomSheetViewTopConstraint.constant = safeAreaHeight + bottomPadding
-        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
-            self.dimmedBackView.alpha = 0.0
-            self.view.layoutIfNeeded()
-        }) { _ in
-            if self.presentingViewController != nil {
-                self.dismiss(animated: false, completion: nil)
+        switch status {
+        case .show:
+            bottomSheetViewTopConstraint.constant = (safeAreaHeight + bottomPadding) - bottomHeight
+            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+                self.dimmedBackView.alpha = 0.5
+                self.view.layoutIfNeeded()
+            }, completion: nil)
+        case .hide:
+            bottomSheetViewTopConstraint.constant = safeAreaHeight + bottomPadding
+            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+                self.dimmedBackView.alpha = 0.0
+                self.view.layoutIfNeeded()
+            }) { _ in
+                if self.presentingViewController != nil {
+                    self.dismiss(animated: false, completion: nil)
+                }
             }
         }
     }
     
     @objc private func dimmedViewTapped(_ tapRecognizer: UITapGestureRecognizer) {
-        hideBottomSheet()
+        setBottomSheetStatus(to: .hide)
     }
     
     @objc private func panGesture(_ recognizer: UISwipeGestureRecognizer) {
         if recognizer.state == .ended {
             switch recognizer.direction {
             case .down:
-                hideBottomSheet()
+                setBottomSheetStatus(to: .hide)
             default:
                 break
             }

--- a/FindTown/FindTown/Presentation/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/FindTown/FindTown/Presentation/Common/ViewController/BaseBottomSheetViewController.swift
@@ -1,0 +1,141 @@
+//
+//  BaseBottomSheetViewController.swift
+//  FindTown
+//
+//  Created by 김성훈 on 2022/12/15.
+//
+
+import UIKit
+
+class BaseBottomSheetViewController: BaseViewController {
+    
+    private let bottomHeight: CGFloat = 360
+    private var bottomSheetViewTopConstraint: NSLayoutConstraint!
+    
+    private lazy var dimmedBackView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.alpha = 0.0
+        return view
+    }()
+    
+    lazy var bottomSheetView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 27
+        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    private lazy var dismissIndicatorView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemGray2
+        view.layer.cornerRadius = 3
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupGestureRecognizer()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        showBottomSheet()
+    }
+    
+    override func addView() {
+        [dimmedBackView, bottomSheetView, dismissIndicatorView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setLayout() {
+        NSLayoutConstraint.activate([
+            dimmedBackView.topAnchor.constraint(equalTo: view.topAnchor),
+            dimmedBackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dimmedBackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            dimmedBackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first as? UIWindowScene
+        let window = windowScene?.windows.first
+        let top = window?.safeAreaInsets.top ?? 0
+        let bottom = window?.safeAreaInsets.bottom ?? 0
+        
+        let topConstant = view.safeAreaInsets.bottom + view.safeAreaLayoutGuide.layoutFrame.height
+        bottomSheetViewTopConstraint = bottomSheetView.topAnchor.constraint(
+            equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topConstant - top - bottom
+        )
+        NSLayoutConstraint.activate([
+            bottomSheetView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            bottomSheetView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            bottomSheetView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            bottomSheetViewTopConstraint
+        ])
+        
+        NSLayoutConstraint.activate([
+            dismissIndicatorView.widthAnchor.constraint(equalToConstant: 100),
+            dismissIndicatorView.heightAnchor.constraint(equalToConstant: 7),
+            dismissIndicatorView.topAnchor.constraint(equalTo: bottomSheetView.topAnchor, constant: 10),
+            dismissIndicatorView.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor)
+        ])
+    }
+    
+    private func setupGestureRecognizer() {
+        let dimmedTap = UITapGestureRecognizer(target: self, action: #selector(dimmedViewTapped(_:)))
+        dimmedBackView.addGestureRecognizer(dimmedTap)
+        dimmedBackView.isUserInteractionEnabled = true
+        
+        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(panGesture))
+        swipeGesture.direction = .down
+        view.addGestureRecognizer(swipeGesture)
+    }
+    
+    private func showBottomSheet() {
+        let safeAreaHeight: CGFloat = view.safeAreaLayoutGuide.layoutFrame.height
+        let bottomPadding: CGFloat = view.safeAreaInsets.bottom
+        
+        bottomSheetViewTopConstraint.constant = (safeAreaHeight + bottomPadding) - bottomHeight
+        
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+            self.dimmedBackView.alpha = 0.5
+            self.view.layoutIfNeeded()
+        }, completion: nil)
+    }
+    
+    private func hideBottomSheet() {
+        let safeAreaHeight = view.safeAreaLayoutGuide.layoutFrame.height
+        let bottomPadding = view.safeAreaInsets.bottom
+        
+        bottomSheetViewTopConstraint.constant = safeAreaHeight + bottomPadding
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+            self.dimmedBackView.alpha = 0.0
+            self.view.layoutIfNeeded()
+        }) { _ in
+            if self.presentingViewController != nil {
+                self.dismiss(animated: false, completion: nil)
+            }
+        }
+    }
+    
+    @objc private func dimmedViewTapped(_ tapRecognizer: UITapGestureRecognizer) {
+        hideBottomSheet()
+    }
+    
+    @objc private func panGesture(_ recognizer: UISwipeGestureRecognizer) {
+        if recognizer.state == .ended {
+            switch recognizer.direction {
+            case .down:
+                hideBottomSheet()
+            default:
+                break
+            }
+        }
+    }
+}

--- a/FindTown/FindTown/Presentation/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/FindTown/FindTown/Presentation/Common/ViewController/BaseBottomSheetViewController.swift
@@ -14,7 +14,7 @@ class BaseBottomSheetViewController: BaseViewController {
         case hide
     }
     
-    private let bottomHeight: CGFloat = 360
+    var bottomHeight: CGFloat
     private var bottomSheetViewTopConstraint: NSLayoutConstraint!
     
     private lazy var dimmedBackView: UIView = {
@@ -42,6 +42,15 @@ class BaseBottomSheetViewController: BaseViewController {
         view.layer.cornerRadius = 3
         return view
     }()
+    
+    init(bottomHeight: CGFloat) {
+         self.bottomHeight = bottomHeight
+         super.init(nibName: nil, bundle: nil)
+     }
+     
+     required init?(coder: NSCoder) {
+         fatalError("init(coder:) has not been implemented")
+     }
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
## Motivation
- issue number :  #9 

## Screen Shots 
<img width="496" alt="스크린샷 2022-12-16 오후 6 32 38" src="https://user-images.githubusercontent.com/50910456/208068125-77f0f54d-a970-4b41-bfaa-93acf6360f17.png">

![Simulator Screen Recording - iPhone 14 - 2022-12-16 at 18 30 58](https://user-images.githubusercontent.com/50910456/208067846-efbe6e4f-1946-4648-88cf-8ab62e724729.gif)

## To Reviewers
- BaseBottomSheetViewController를 상속받아서 바텀시트를 만들고 modal fullScreen으로 띄웁니다.
- 바텀시트를 bottomHeight 만큼 보이게 합니다. ( 바텀시트 높이가 정해지면 수정하겠습니다 :) )
- 상속받아서 쓰는 거라 이름도 Base붙이고, Common - ViewController 에 넣어놨는데 의견주시면 감사하겠습니다!! 😀
