### PR TITLE
UI Component중 PopUp 구현

### DIFF
--- a/FindTown/FindTownCore/Sources/FindTownCore/Base/BaseViewController.swift
+++ b/FindTown/FindTownCore/Sources/FindTownCore/Base/BaseViewController.swift
@@ -14,6 +14,8 @@ open class BaseViewController: UIViewController {
     
     open override func viewDidLoad() {
         super.viewDidLoad()
+        hideKeyboard()
+        
         addView()
         setupView()
         setLayout()

--- a/FindTown/FindTownCore/Sources/FindTownCore/Extensions/UIViewController+Extension.swift
+++ b/FindTown/FindTownCore/Sources/FindTownCore/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by 장선영 on 2022/12/28.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+
+    /// 화면 탭시 키보드 숨기기
+    public func hideKeyboard() {
+        let tapGesture = UITapGestureRecognizer(target: self,
+                                                action: #selector(UIViewController.dismissKeyboard))
+        view.addGestureRecognizer(tapGesture)
+    }
+}
+
+private extension UIViewController {
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/AlertPopUpViewController.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/AlertPopUpViewController.swift
@@ -1,0 +1,97 @@
+//
+//  AlertPopUpViewController.swift
+//  
+//
+//  Created by 장선영 on 2022/12/27.
+//
+
+import UIKit
+
+public class AlertPopUpViewController: UIViewController {
+    
+    private var messageText: String = ""
+    private var buttonText: String = ""
+    
+    private var contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = FindTownColor.white.color
+        view.layer.cornerRadius = 16
+        
+        /// 애니메이션
+        view.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private lazy var messageLabel: FindTownLabel = {
+        let label = FindTownLabel(text: messageText,
+                                  font: .body3,
+                                  textColor: .black,
+                                  textAlignment: .center)
+        label.numberOfLines = 0
+        label.setLineHeight(lineHeight: 20.0)
+        return label
+    }()
+    
+    private lazy var button: FTButton = {
+        let button = FTButton(style: .mediumFilled)
+        button.setTitle(buttonText, for: .normal)
+        return button
+    }()
+       
+    public convenience init(messageText: String,
+                            buttonText: String,
+                            buttonAction: (() -> Void)? = nil) {
+        self.init()
+
+        self.messageText = messageText
+        self.buttonText = buttonText
+        self.button.addAction(for: .touchUpInside) { _ in
+            buttonAction?()
+        }
+        
+        /// present 시 fullScreen (화면 덮도록)
+        modalPresentationStyle = .overFullScreen
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.backgroundColor = FindTownColor.dim70.color
+        setLayout()
+    }
+}
+
+private extension AlertPopUpViewController {
+    
+    func setLayout() {
+        
+        self.view.addSubview(contentView)
+        
+        [messageLabel, button].forEach {
+            self.contentView.addSubview($0)
+        }
+
+        let view = self.view.safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            contentView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            contentView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 48.0)
+        ])
+        
+        NSLayoutConstraint.activate([
+            messageLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 32.0),
+            messageLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20.0),
+            messageLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            button.heightAnchor.constraint(equalToConstant: 48.0),
+            button.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: 32.0),
+            button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16.0),
+            button.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16.0)
+        ])
+    }
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/Extensions/UIControl+Extension.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Extensions/UIControl+Extension.swift
@@ -1,0 +1,47 @@
+//
+//  File.swift
+//  
+//
+//  Created by 장선영 on 2022/12/27.
+//
+
+import Foundation
+import UIKit
+
+extension UIControl {
+    public typealias UIControlTargetClosure = (UIControl) -> ()
+
+    private class UIControlClosureWrapper: NSObject {
+        let closure: UIControlTargetClosure
+        init(_ closure: @escaping UIControlTargetClosure) {
+            self.closure = closure
+        }
+    }
+
+    private struct AssociatedKeys {
+        static var targetClosure = "targetClosure"
+    }
+
+    private var targetClosure: UIControlTargetClosure? {
+        get {
+            guard let closureWrapper = objc_getAssociatedObject(self, &AssociatedKeys.targetClosure) as? UIControlClosureWrapper else { return nil }
+            return closureWrapper.closure
+
+        } set(newValue) {
+            guard let newValue = newValue else { return }
+            objc_setAssociatedObject(self, &AssociatedKeys.targetClosure, UIControlClosureWrapper(newValue),
+                                     objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    @objc func closureAction() {
+        guard let targetClosure = targetClosure else { return }
+        targetClosure(self)
+    }
+
+    public func addAction(for event: UIControl.Event, closure: @escaping UIControlTargetClosure) {
+        targetClosure = closure
+        addTarget(self, action: #selector(UIControl.closureAction), for: event)
+    }
+
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/Extensions/UIViewController+Extension.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Extensions/UIViewController+Extension.swift
@@ -16,8 +16,19 @@ extension UIViewController {
                                                 action: #selector(UIViewController.dismissKeyboard))
         view.addGestureRecognizer(tapGesture)
     }
+    
+    /// AlertPopUpVC 띄워 줌
+    public func showAlertPopUp(message: String, buttonText: String, buttonAction: @escaping () -> Void) {
+        let alertPopUp = AlertPopUpViewController(messageText: message,
+                                                  buttonText: buttonText,
+                                                  buttonAction: buttonAction)
+        present(alertPopUp, animated: false)
+    }
+}
 
-    @objc private func dismissKeyboard() {
+private extension UIViewController {
+    
+    @objc func dismissKeyboard() {
         view.endEditing(true)
     }
 }

--- a/FindTown/FindTownUI/Sources/FindTownUI/Extensions/UIViewController+Extension.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Extensions/UIViewController+Extension.swift
@@ -10,13 +10,6 @@ import UIKit
 
 extension UIViewController {
 
-    /// 화면 탭시 키보드 숨기기
-    public func hideKeyboard() {
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(UIViewController.dismissKeyboard))
-        view.addGestureRecognizer(tapGesture)
-    }
-    
     /// AlertPopUpVC 띄워 줌
     public func showAlertPopUp(message: String, buttonText: String, buttonAction: @escaping () -> Void) {
         let alertPopUp = AlertPopUpViewController(messageText: message,
@@ -26,9 +19,3 @@ extension UIViewController {
     }
 }
 
-private extension UIViewController {
-    
-    @objc func dismissKeyboard() {
-        view.endEditing(true)
-    }
-}

--- a/FindTown/FindTownUI/Sources/FindTownUI/Label/FindTownLabel.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Label/FindTownLabel.swift
@@ -30,3 +30,25 @@ public final class FindTownLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+public extension FindTownLabel {
+     
+    /// 행간이 추가되어야하는 경우 사용
+    func setLineHeight(lineHeight: CGFloat) {
+        if let text = self.text {
+            let style = NSMutableParagraphStyle()
+            style.maximumLineHeight = lineHeight
+            style.minimumLineHeight = lineHeight
+            style.alignment = self.textAlignment
+            
+            let attributes: [NSAttributedString.Key: Any] = [
+                .paragraphStyle: style,
+                .baselineOffset: (lineHeight - font.lineHeight) / 4,
+            ]
+                
+            let attrString = NSAttributedString(string: text,
+                                                attributes: attributes)
+            self.attributedText = attrString
+        }
+    }
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/PopUp/AlertPopUpViewController.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/PopUp/AlertPopUpViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 텍스트와 버튼으로만 구성된 알림 팝업
 public class AlertPopUpViewController: UIViewController {
     
     private var messageText: String = ""
@@ -16,9 +17,6 @@ public class AlertPopUpViewController: UIViewController {
         let view = UIView()
         view.backgroundColor = FindTownColor.white.color
         view.layer.cornerRadius = 16
-        
-        /// 애니메이션
-        view.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/FindTown/FindTownUI/Sources/FindTownUI/PopUp/ContentPopUpViewController.swift
+++ b/FindTown/FindTownUI/Sources/FindTownUI/PopUp/ContentPopUpViewController.swift
@@ -1,0 +1,77 @@
+//
+//  ContentPopUpViewController.swift
+//  
+//
+//  Created by 장선영 on 2022/12/28.
+//
+
+import UIKit
+
+/// 사용자 지정 콘텐츠View가 들어가는 팝업 VC
+open class ContentPopUpViewController: UIViewController {
+        
+    public var contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = FindTownColor.white.color
+        view.layer.cornerRadius = 16
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    public var topLeftButton: UIButton = {
+        let button = UIButton()
+        button.setTitleColor(FindTownColor.black.color, for: .normal)
+        button.setImage(UIImage(named: "Close", in: .module, compatibleWith: nil), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    public var titleLabel: FindTownLabel = {
+        let label = FindTownLabel(text: "",
+                                  font: .body1,
+                                  textColor: .black,
+                                  textAlignment: .center)
+        label.setLineHeight(lineHeight: 24.0)
+        return label
+    }()
+
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = FindTownColor.dim70.color
+        modalPresentationStyle = .overFullScreen
+        
+        setLayout()
+    }
+}
+
+private extension ContentPopUpViewController {
+    
+    func setLayout() {
+        
+        self.view.addSubview(contentView)
+        
+        [topLeftButton, titleLabel].forEach {
+            self.contentView.addSubview($0)
+        }
+        
+        let view = self.view.safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            contentView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            contentView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+            contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32.0)
+        ])
+        
+        NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 19.0)
+        ])
+        
+        NSLayoutConstraint.activate([
+            topLeftButton.widthAnchor.constraint(equalToConstant: 14.0),
+            topLeftButton.heightAnchor.constraint(equalToConstant: 14.0),
+            topLeftButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24.0),
+            topLeftButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor)
+        ])
+    }
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Back.imageset/Back.svg
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Back.imageset/Back.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 1L1 7L7 13" stroke="#444444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Back.imageset/Contents.json
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Back.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "Back.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Close.imageset/Close.svg
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Close.imageset/Close.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z" fill="#444444"/>
+</svg>

--- a/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Close.imageset/Contents.json
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Close.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "Close.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Contents.json
+++ b/FindTown/FindTownUI/Sources/FindTownUI/Resource/Assets.xcassets/Image/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Motivation
- issue number : #9 

## Changes
- AlertPopUpViewController - 텍스트와 버튼으로만 구성된 알림 팝업용 VC 구현
  - 팝업 내 버튼 Action을 클로져로 받기 위해 UIControl+Extension에 관련 메서드 추가
  - AlertPopUpVC present하는 메서드 UIViewControl+Extension에 추가
- ContentPopUpViewController - 사용자 설정 뷰가 들어가는 팝업 VC 구현
- FindTownLabel 내에 행간 추가하는 메서드 setLineHeight() 추가

## Screen Shots

### AlertPopUpViewController
<img width="259" alt="스크린샷 2022-12-28 오후 3 07 33" src="https://user-images.githubusercontent.com/77603632/209673892-72091139-78f6-4f47-a586-55f229f612cc.jpg">

### 테스트 코드
```
@objc func tapButton() {
        self.showAlertPopUp(message: "제보해주셔서 감사합니다.\n 빠른 시일 내에 반영하도록 하겠습니다.",
                            buttonText: "확인",
                            buttonAction: {
            self.dismiss(animated: false)
            print("tap button")
        })
    }
```
```
extension UIViewController {
    public func showAlertPopUp(message: String, buttonText: String, buttonAction: @escaping () -> Void) {
        let alertPopUp = AlertPopUpViewController(messageText: message,
                                                  buttonText: buttonText,
                                                  buttonAction: buttonAction)
        present(alertPopUp, animated: false)
    }
}
```
### ContentPopUpViewController
<img width="259" alt="스크린샷 2022-12-28 오후 3 07 33" src="https://user-images.githubusercontent.com/77603632/209765486-31a4b8e8-ff57-4675-9ffc-d11901bf2af1.png">

 -  피그마 참고

<img width="259" alt="스크린샷 2022-12-28 오후 3 07 33" src="https://user-images.githubusercontent.com/77603632/209766135-809b2e95-9e85-487b-affa-41a5b1ce5826.png">
<img width="239" alt="스크린샷 2022-12-28 오후 3 08 27" src="https://user-images.githubusercontent.com/77603632/209766251-27c335f1-aa24-4dac-b904-fcc085cd7efe.png">

### 테스트 코드
```
import UIKit
import FindTownUI

class ViewController: ContentPopUpViewController {

    override func viewDidLoad() {
        super.viewDidLoad()
        
        titleLabel.text = "ContentPopUpView test"
        
        let pinkView = UIView()
        pinkView.backgroundColor = .systemPink
        pinkView.translatesAutoresizingMaskIntoConstraints = false
        
        contentView.addSubview(pinkView)
        
        NSLayoutConstraint.activate([
            pinkView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20.0),
            pinkView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20.0),
            pinkView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
            pinkView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -30.0),
            pinkView.heightAnchor.constraint(equalToConstant: 400.0)
        ])
    }
}
```
## To Reviewers
- AlertPopUpViewController는 팝업 뷰의 형식은 그대로고 텍스트만 바뀌기에 init할 때 텍스트와 버튼 액션을 클로져로 전달하도록 구현하였습니다.
  - 버튼은 성훈님께서 수정하신 버튼 머지하고 난 후에 다시 수정할 예정입니다..!!
- ContentPopUpViewController는 상단 타이틀과 상단 왼쪽 버튼만 고정이고 내부의 뷰는 사용자가 구현해야하더라구요..! 그래서 사용자 커스텀 View를 전달받는 방식과 ContentPopUpVC를 상속받아서 커스텀하는 방식 중 고민하다가 상속받는 방식으로 구현해보았는데 의견이 궁금합니다..!
- 추가로 이미지 파일 어떻게 추출하고 계신가요? 피그마에서 추출하고 있다보니 저는 svg가 편하긴 하더라구요.. 하나만 받아도 되어서..핳