### PR TITLE
카카오 로그인 기능

### DIFF
--- a/FindTown/FindTown.xcodeproj/project.pbxproj
+++ b/FindTown/FindTown.xcodeproj/project.pbxproj
@@ -9,6 +9,13 @@
 /* Begin PBXBuildFile section */
 		2B718C182966A5930068884A /* MapCategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B718C172966A5930068884A /* MapCategoryCollectionViewCell.swift */; };
 		2B718C1A2966A6000068884A /* MapCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B718C192966A6000068884A /* MapCategory.swift */; };
+		BC04A6CA296FB8B200B60BCF /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = BC04A6C9296FB8B200B60BCF /* KakaoSDKAuth */; };
+		BC04A6CC296FB8B200B60BCF /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = BC04A6CB296FB8B200B60BCF /* KakaoSDKCommon */; };
+		BC04A6CE296FB8B200B60BCF /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = BC04A6CD296FB8B200B60BCF /* KakaoSDKUser */; };
+		BC04A6D0296FB9BF00B60BCF /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC04A6CF296FB9BF00B60BCF /* APIKeyInfo.plist */; };
+		BC04A6D4296FBC5C00B60BCF /* SigninManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC04A6D3296FBC5C00B60BCF /* SigninManagerProtocol.swift */; };
+		BC04A6D6296FBC6F00B60BCF /* KakaoSigninManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC04A6D5296FBC6F00B60BCF /* KakaoSigninManager.swift */; };
+		BC04A6D9296FBC8E00B60BCF /* UserDefaultUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC04A6D8296FBC8E00B60BCF /* UserDefaultUtil.swift */; };
 		BC056C562962B29F00EDCA18 /* SignupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC056C552962B29F00EDCA18 /* SignupCoordinator.swift */; };
 		BC056C5A2962B2B900EDCA18 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC056C592962B2B900EDCA18 /* LoginViewModel.swift */; };
 		BC056C5C2962B2C400EDCA18 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC056C5B2962B2C400EDCA18 /* LoginViewController.swift */; };
@@ -35,7 +42,6 @@
 		F31A80C82949A5BB003B8A6E /* FindTownCore in Frameworks */ = {isa = PBXBuildFile; productRef = F31A80C72949A5BB003B8A6E /* FindTownCore */; };
 		F31A80CA2949A5BB003B8A6E /* FindTownNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = F31A80C92949A5BB003B8A6E /* FindTownNetwork */; };
 		F31A80CC2949A5BB003B8A6E /* FindTownUI in Frameworks */ = {isa = PBXBuildFile; productRef = F31A80CB2949A5BB003B8A6E /* FindTownUI */; };
-		F3219B5B29693F12000024E4 /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F3219B5A29693F12000024E4 /* APIKeyInfo.plist */; };
 		F3219B5E2969403F000024E4 /* MapData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3219B5D2969403F000024E4 /* MapData.swift */; };
 		F3219B602969407A000024E4 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3219B5F29694079000024E4 /* Category.swift */; };
 		F3219B622969408C000024E4 /* DetailCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3219B612969408C000024E4 /* DetailCategory.swift */; };
@@ -96,6 +102,10 @@
 /* Begin PBXFileReference section */
 		2B718C172966A5930068884A /* MapCategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		2B718C192966A6000068884A /* MapCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCategory.swift; sourceTree = "<group>"; };
+		BC04A6CF296FB9BF00B60BCF /* APIKeyInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKeyInfo.plist; path = ../../../../../../Downloads/APIKeyInfo.plist; sourceTree = "<group>"; };
+		BC04A6D3296FBC5C00B60BCF /* SigninManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninManagerProtocol.swift; sourceTree = "<group>"; };
+		BC04A6D5296FBC6F00B60BCF /* KakaoSigninManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSigninManager.swift; sourceTree = "<group>"; };
+		BC04A6D8296FBC8E00B60BCF /* UserDefaultUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultUtil.swift; sourceTree = "<group>"; };
 		BC056C552962B29F00EDCA18 /* SignupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupCoordinator.swift; sourceTree = "<group>"; };
 		BC056C592962B2B900EDCA18 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		BC056C5B2962B2C400EDCA18 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -117,7 +127,6 @@
 		F31A80C32949A556003B8A6E /* FindTownUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FindTownUI; sourceTree = "<group>"; };
 		F31A80C42949A568003B8A6E /* FindTownCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FindTownCore; sourceTree = "<group>"; };
 		F31A80C52949A577003B8A6E /* FindTownNetwork */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FindTownNetwork; sourceTree = "<group>"; };
-		F3219B5A29693F12000024E4 /* APIKeyInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKeyInfo.plist; sourceTree = "<group>"; };
 		F3219B5D2969403F000024E4 /* MapData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapData.swift; sourceTree = "<group>"; };
 		F3219B5F29694079000024E4 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		F3219B612969408C000024E4 /* DetailCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCategory.swift; sourceTree = "<group>"; };
@@ -168,6 +177,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F31A80CA2949A5BB003B8A6E /* FindTownNetwork in Frameworks */,
+				BC04A6CE296FB8B200B60BCF /* KakaoSDKUser in Frameworks */,
 				BC6EFB83293BD12300AB3332 /* RxSwift in Frameworks */,
 				F31A80C82949A5BB003B8A6E /* FindTownCore in Frameworks */,
 				BC6EFB86293BD15A00AB3332 /* RxDataSources in Frameworks */,
@@ -175,6 +185,8 @@
 				BC99019C295F09720051CC9B /* NMapsMap in Frameworks */,
 				BC6EFB81293BD12300AB3332 /* RxRelay in Frameworks */,
 				BC6EFB7F293BD12300AB3332 /* RxCocoa in Frameworks */,
+				BC04A6CC296FB8B200B60BCF /* KakaoSDKCommon in Frameworks */,
+				BC04A6CA296FB8B200B60BCF /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -195,6 +207,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BC04A6D1296FBC3900B60BCF /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				BC04A6D3296FBC5C00B60BCF /* SigninManagerProtocol.swift */,
+				BC04A6D5296FBC6F00B60BCF /* KakaoSigninManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
+		BC04A6D7296FBC7900B60BCF /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				BC04A6D8296FBC8E00B60BCF /* UserDefaultUtil.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		BC056C512962B03B00EDCA18 /* AuthScene */ = {
 			isa = PBXGroup;
 			children = (
@@ -286,6 +315,7 @@
 		BC6EFB75293B9C3800AB3332 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				BC04A6D7296FBC7900B60BCF /* Utils */,
 				BC056C512962B03B00EDCA18 /* AuthScene */,
 				F38CCBD92958287C000C16AF /* HomeScene */,
 				F38CCBE229582881000C16AF /* MapScene */,
@@ -305,8 +335,8 @@
 		BC6EFB7A293BA31D00AB3332 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
-				F3219B5A29693F12000024E4 /* APIKeyInfo.plist */,
 				F3891E2A293B8394003CE8AD /* Assets.xcassets */,
+				BC04A6CF296FB9BF00B60BCF /* APIKeyInfo.plist */,
 				F3891E2F293B8394003CE8AD /* Info.plist */,
 				F3891E2C293B8394003CE8AD /* LaunchScreen.storyboard */,
 			);
@@ -408,6 +438,7 @@
 		F3891E1D293B8393003CE8AD /* FindTown */ = {
 			isa = PBXGroup;
 			children = (
+				BC04A6D1296FBC3900B60BCF /* Manager */,
 				BC6EFB7A293BA31D00AB3332 /* Resource */,
 				BC6EFB75293B9C3800AB3332 /* Presentation */,
 				BC6EFB74293B9C3400AB3332 /* Domain */,
@@ -533,6 +564,9 @@
 				F31A80C92949A5BB003B8A6E /* FindTownNetwork */,
 				F31A80CB2949A5BB003B8A6E /* FindTownUI */,
 				BC99019B295F09720051CC9B /* NMapsMap */,
+				BC04A6C9296FB8B200B60BCF /* KakaoSDKAuth */,
+				BC04A6CB296FB8B200B60BCF /* KakaoSDKCommon */,
+				BC04A6CD296FB8B200B60BCF /* KakaoSDKUser */,
 			);
 			productName = FindTown;
 			productReference = F3891E1B293B8393003CE8AD /* FindTown.app */;
@@ -614,6 +648,7 @@
 				BC6EFB7D293BD12300AB3332 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				BC6EFB84293BD15A00AB3332 /* XCRemoteSwiftPackageReference "RxDataSources" */,
 				BC99019A295F09720051CC9B /* XCRemoteSwiftPackageReference "NMapsMap-SPM" */,
+				BC04A6C8296FB8B200B60BCF /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = F3891E1C293B8393003CE8AD /* Products */;
 			projectDirPath = "";
@@ -632,7 +667,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3891E2E293B8394003CE8AD /* LaunchScreen.storyboard in Resources */,
-				F3219B5B29693F12000024E4 /* APIKeyInfo.plist in Resources */,
+				BC04A6D0296FB9BF00B60BCF /* APIKeyInfo.plist in Resources */,
 				F3891E2B293B8394003CE8AD /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -669,6 +704,7 @@
 				F39EDDD0296D7BBF00A4E655 /* StoreCollectionView.swift in Sources */,
 				F39EDDC8296D748200A4E655 /* CityCollectionView.swift in Sources */,
 				F38CCBEA29582881000C16AF /* MapCoordinator.swift in Sources */,
+				BC04A6D4296FBC5C00B60BCF /* SigninManagerProtocol.swift in Sources */,
 				F39EDDC2296D635100A4E655 /* CityType.swift in Sources */,
 				BCE814F62967DAF200A6E3CB /* LoginCoordinator.swift in Sources */,
 				BC9F4D5E296BF0C90099473C /* AgreePolicyViewController.swift in Sources */,
@@ -691,6 +727,7 @@
 				BC9E86522966821C00AB4AE7 /* SignupViewModelDelegate.swift in Sources */,
 				F38CCBE829582881000C16AF /* MapViewController.swift in Sources */,
 				2B718C182966A5930068884A /* MapCategoryCollectionViewCell.swift in Sources */,
+				BC04A6D9296FBC8E00B60BCF /* UserDefaultUtil.swift in Sources */,
 				F38CCBD829582869000C16AF /* TabBarCoordinator.swift in Sources */,
 				F3219B692969432C000024E4 /* MapDetailComponentView.swift in Sources */,
 				F3219B7A2969D53D000024E4 /* AddressSheetCoordinator.swift in Sources */,
@@ -710,6 +747,7 @@
 				F3891E21293B8393003CE8AD /* SceneDelegate.swift in Sources */,
 				F39EDDC4296D667800A4E655 /* County.swift in Sources */,
 				F3219B742969B351000024E4 /* StoreDetailType.swift in Sources */,
+				BC04A6D6296FBC6F00B60BCF /* KakaoSigninManager.swift in Sources */,
 				F39EDDCA296D788800A4E655 /* CityCollectionViewFlowLayout.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -879,13 +917,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CADXU3X8JU;
+				DEVELOPMENT_TEAM = F92UQYH2RA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindTown/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -907,13 +946,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CADXU3X8JU;
+				DEVELOPMENT_TEAM = F92UQYH2RA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindTown/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1046,6 +1086,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		BC04A6C8296FB8B200B60BCF /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		BC6EFB7D293BD12300AB3332 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift.git";
@@ -1073,6 +1121,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		BC04A6C9296FB8B200B60BCF /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC04A6C8296FB8B200B60BCF /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		BC04A6CB296FB8B200B60BCF /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC04A6C8296FB8B200B60BCF /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		BC04A6CD296FB8B200B60BCF /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC04A6C8296FB8B200B60BCF /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
 		BC6EFB7E293BD12300AB3332 /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BC6EFB7D293BD12300AB3332 /* XCRemoteSwiftPackageReference "RxSwift" */;

--- a/FindTown/FindTown.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FindTown/FindTown.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "78424be314842833c04bc3bef5b72e85fff99204",
+        "version" : "5.6.4"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "b1d700ddaba7c7ff8eea56145a2b11fcb6ae037e"
+      }
+    },
+    {
       "identity" : "nmapsmap-spm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jaemyeong/NMapsMap-SPM.git",

--- a/FindTown/FindTown/Application/AppDelegate.swift
+++ b/FindTown/FindTown/Application/AppDelegate.swift
@@ -10,6 +10,7 @@ import CoreData
 import FindTownUI
 import FindTownCore
 import NMapsMap
+import KakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -21,6 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // NaverMap API Set
         NMFAuthManager.shared().clientId = Bundle.main.NAVER_MAP_KEY
+        
+        // KAKAO SDK Set
+        KakaoSDK.initSDK(appKey: Bundle.main.KAKAO_NATIVE_APP_KEY)
         
         return true
     }
@@ -85,4 +89,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/FindTown/FindTown/Application/SceneDelegate.swift
+++ b/FindTown/FindTown/Application/SceneDelegate.swift
@@ -7,11 +7,19 @@
 
 import UIKit
 import FindTownCore
+import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
+    }
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -20,8 +28,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
+        let userDefaultUtil = UserDefaultUtil()
+
         let navigationController = BaseNavigationController()
-        AppCoordinator(navigationController: navigationController).start()
+        AppCoordinator(navigationController: navigationController, userDefaults: userDefaultUtil).start()
         
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
@@ -60,4 +70,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     
 }
-

--- a/FindTown/FindTown/Manager/KakaoSigninManager.swift
+++ b/FindTown/FindTown/Manager/KakaoSigninManager.swift
@@ -1,0 +1,168 @@
+//
+//  KakaoSignUpManager.swift
+//  FindTown
+//
+//  Created by 김성훈 on 2023/01/04.
+//
+
+import Foundation
+
+import KakaoSDKUser
+import KakaoSDKAuth
+import KakaoSDKCommon
+import RxSwift
+
+// 어디로 빼지
+enum BaseError: LocalizedError {
+    case custom(String)
+    case unknown
+    case timeout
+    case failDecoding
+    case nilValue
+    
+    var errorDescription: String? {
+        switch self {
+        case .custom(let message):
+            return message
+        case .unknown:
+            return "error_unknown"
+        case .timeout:
+            return "http_error_timeout"
+        case .failDecoding:
+            return "error_failed_to_json"
+        case .nilValue:
+            return "error_value_is_nil"
+        }
+    }
+}
+
+final class KakaoSigninManager: SigninManagerProtocol {
+    
+    private var disposeBag = DisposeBag()
+    
+    private var publisher = PublishSubject<SigninRequest>()
+    
+    func signin() -> Observable<SigninRequest> {
+        self.publisher = PublishSubject<SigninRequest>()
+        
+        if UserApi.isKakaoTalkLoginAvailable() {
+            self.signInWithKakaoTalk()
+            
+        } else {
+            self.signInWithKakaoAccount()
+        }
+        return self.publisher
+    }
+    
+    // logout API -> accessToken, refreshToken 날아감
+    // signout : logoutAPI 호출 + userDefault, 서버 유저정보 다 날려야함
+    func signout() -> Observable<Void> {
+        return .create { observer in
+            UserApi.shared.logout { error in
+                if let kakaoError = error as? SdkError,
+                   kakaoError.getApiError().reason == .InvalidAccessToken {
+                    observer.onNext(())
+                    observer.onCompleted()
+                } else if let error = error {
+                    observer.onError(error)
+                } else {
+                    observer.onNext(())
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create()
+        }
+    }
+    
+    func logout() -> Observable<Void> {
+        return .create { observer in
+            UserApi.shared.logout { error in
+                if let kakaoError = error as? SdkError,
+                   kakaoError.getApiError().reason == .InvalidAccessToken {
+                    observer.onNext(())
+                    observer.onCompleted()
+                } else if let error = error {
+                    observer.onError(error)
+                } else {
+                    observer.onNext(())
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create()
+        }
+    }
+    
+    private func signInWithKakaoTalk() {
+        UserApi.shared.loginWithKakaoTalk { authToken, error in
+            if let error = error {
+                if let sdkError = error as? SdkError {
+                    if sdkError.isClientFailed {
+                        switch sdkError.getClientError().reason {
+                        case .Cancelled:
+                            self.publisher.onError(BaseError.custom("cancel"))
+                        default:
+                            let errorMessage = sdkError.getApiError().info?.msg ?? ""
+                            let error = BaseError.custom(errorMessage)
+                            
+                            self.publisher.onError(error)
+                        }
+                    }
+                } else {
+                    let signInError
+                    = BaseError.custom("error is not SdkError. (\(error.self))")
+                    
+                    self.publisher.onError(signInError)
+                }
+            } else {
+                guard let authToken = authToken else {
+                    self.publisher.onError(BaseError.custom("authToken is nil"))
+                    return
+                }
+                let request = SigninRequest(
+                    signinType: .kakao,
+                    accessToken: authToken.accessToken
+                )
+
+                self.publisher.onNext(request)
+                self.publisher.onCompleted()
+            }
+        }
+    }
+    
+    private func signInWithKakaoAccount() {
+        UserApi.shared.loginWithKakaoAccount { authToken, error in
+            if let error = error {
+                if let sdkError = error as? SdkError {
+                    if sdkError.isClientFailed {
+                        switch sdkError.getClientError().reason {
+                        case .Cancelled:
+                            self.publisher.onError(BaseError.custom("cancel"))
+                        default:
+                            let errorMessage = sdkError.getApiError().info?.msg ?? ""
+                            let error = BaseError.custom(errorMessage)
+                            
+                            self.publisher.onError(error)
+                        }
+                    }
+                } else {
+                    let signInError
+                    = BaseError.custom("error is not SdkError. (\(error.self))")
+                    
+                    self.publisher.onError(signInError)
+                }
+            } else {
+                guard let authToken = authToken else {
+                    self.publisher.onError(BaseError.custom("authToken is nil"))
+                    return
+                }
+                let request = SigninRequest(
+                    signinType: .kakao,
+                    accessToken: authToken.accessToken
+                )
+                
+                self.publisher.onNext(request)
+                self.publisher.onCompleted()
+            }
+        }
+    }
+}

--- a/FindTown/FindTown/Manager/SigninManagerProtocol.swift
+++ b/FindTown/FindTown/Manager/SigninManagerProtocol.swift
@@ -1,0 +1,73 @@
+//
+//  SignUpManagerProtocol.swift
+//  FindTown
+//
+//  Created by 김성훈 on 2023/01/04.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol SigninManagerProtocol {
+    func signin() -> Observable<SigninRequest>
+    
+    func signout() -> Observable<Void>
+    
+    func logout() -> Observable<Void>
+}
+
+// 따로 분리
+struct SigninRequest {
+    var signinType: SigninType
+    var accessToken: String
+    
+    var params: [String : Any] {
+        return [
+            "signinType": self.signinType.value,
+            "accessToken": self.accessToken
+        ]
+    }
+}
+
+// 따로 분리
+enum SigninType {
+    case kakao
+    case apple
+    case anonymous
+    case unknown
+    
+    init(value: String) {
+        switch value {
+        case "KAKAO":
+            self = .kakao
+            
+        case "APPLE":
+            self = .apple
+            
+        case "ANONYMOUS":
+            self = .anonymous
+            
+        default:
+            self = .unknown
+        }
+    }
+}
+
+extension SigninType {
+    var value: String {
+        switch self {
+        case .kakao:
+            return "KAKAO"
+            
+        case .apple:
+            return "APPLE"
+            
+        case .anonymous:
+            return "ANONYMOUS"
+            
+        case .unknown:
+            return ""
+        }
+    }
+}

--- a/FindTown/FindTown/Presentation/AuthScene/Flows/LoginCoordinator.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Flows/LoginCoordinator.swift
@@ -1,8 +1,8 @@
 //
-//  LoginCoordinator.swift
-//  FindTown
+//  LoginCoordinator.swift
+//  FindTown
 //
-//  Created by 김성훈 on 2023/01/06.
+//  Created by 김성훈 on 2022/12/29.
 //
 
 import UIKit
@@ -18,9 +18,10 @@ final class LoginCoordinator: FlowCoordinator {
         self.presentationStyle = presentationStyle
     }
     
-    /// 로그인 화면
     internal func initScene() -> UIViewController {
-        let loginViewModel = LoginViewModel(delegate: self)
+        let loginViewModel = LoginViewModel(delegate: self,
+                                            userDefaults: UserDefaultUtil(),
+                                            kakaoManager: KakaoSigninManager())
         let loginViewController = LoginViewController(viewModel: loginViewModel)
         return loginViewController
     }
@@ -28,15 +29,14 @@ final class LoginCoordinator: FlowCoordinator {
 
 extension LoginCoordinator: LoginViewModelDelegate {
     
-    func goToNickname() {
-        guard let navigationController = navigationController else { return }
-        navigationController.isNavigationBarHidden = false
-        SignupCoordinator(presentationStyle: .push(navigationController: navigationController)).start()
-    }
-    
     func goToTabBar() {
         guard let navigationController = navigationController else { return }
         navigationController.isNavigationBarHidden = true
         TabBarCoordinator(presentationStyle: .push(navigationController: navigationController)).start()
+    }
+    
+    func goToNickname() {
+        guard let navigationController = navigationController else { return }
+        SignupCoordinator(presentationStyle: .push(navigationController: navigationController)).start()
     }
 }

--- a/FindTown/FindTown/Presentation/AuthScene/Login/LoginViewController.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Login/LoginViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import FindTownCore
 import FindTownUI
+import KakaoSDKUser
 import RxCocoa
 import RxSwift
 
@@ -141,24 +142,24 @@ final class LoginViewController: BaseViewController {
         kakaoButton.rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind { [weak self] in
-                // 임시
-                self?.viewModel?.goToNickname()
+                self?.viewModel?.input.kakaoSigninTrigger.onNext(())
             }
             .disposed(by: disposeBag)
         
         /// apple 로그인
         appleButton.rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .bind {
-                
+            .bind { [weak self] in
+                self?.viewModel?.input.appleSigninTrigger.onNext(())
             }
             .disposed(by: disposeBag)
         
         /// 둘러보기
         anonymousTitleTapGesture.rx.event
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .bind { _ in
-                
+            .bind { [weak self] _ in
+                // userdefault type 익명으로 세팅하고 넘어가기
+                self?.viewModel?.input.anonymousTrigger.onNext(())
             }
             .disposed(by: disposeBag)
         

--- a/FindTown/FindTown/Presentation/AuthScene/Login/LoginViewController.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Login/LoginViewController.swift
@@ -35,7 +35,7 @@ final class LoginViewController: BaseViewController {
         var configuration = UIButton.Configuration.filled()
         configuration.title = "카카오로 시작하기"
         configuration.image = UIImage(named: "KakaoIcon")
-        configuration.baseBackgroundColor = .init(red: 254, green: 229, blue: 0, alpha: 1)
+        configuration.baseBackgroundColor = #colorLiteral(red: 0.9983025193, green: 0.9065476656, blue: 0, alpha: 1)
         configuration.baseForegroundColor = FindTownColor.black.color
         configuration.imagePadding = 9
         configuration.attributedTitle?.font = FindTownFont.body1.font

--- a/FindTown/FindTown/Presentation/AuthScene/Login/LoginViewModel.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Login/LoginViewModel.swift
@@ -8,30 +8,87 @@
 import Foundation
 
 import FindTownCore
+import RxSwift
 
 protocol LoginViewModelType {
-    func goToNickname()
     func goToTabBar()
+    func goToNickname()
 }
 
 final class LoginViewModel: BaseViewModel {
     
+    struct Input {
+        let kakaoSigninTrigger = PublishSubject<Void>()
+        let appleSigninTrigger = PublishSubject<Void>()
+        let anonymousTrigger = PublishSubject<Void>()
+    }
+    
+    struct Output {
+        let signinOutput = PublishSubject<SigninRequest>()
+    }
+    
+    let input = Input()
+    var output = Output()
+    
     let delegate: LoginViewModelDelegate
+    var userDefaults: UserDefaultUtil
+    let kakaoManager: SigninManagerProtocol
     
     init(
-        delegate: LoginViewModelDelegate
+        delegate: LoginViewModelDelegate,
+        userDefaults: UserDefaultUtil,
+        kakaoManager: SigninManagerProtocol
     ) {
         self.delegate = delegate
+        self.userDefaults = userDefaults
+        self.kakaoManager = kakaoManager
+        
+        super.init()
+        
+        self.bind()
+    }
+    
+    func bind() {
+        
+        self.input.kakaoSigninTrigger
+            .flatMapLatest { self.kakaoManager.signin() }
+            .subscribe(onNext: { [weak self] signinRequest in
+                
+                // 임시 -> 회원가입 완료 시점으로 가야함
+                self?.userDefaults.accessToken = signinRequest.accessToken
+                self?.userDefaults.signinType = signinRequest.signinType.value
+                self?.userDefaults.userNickname = "userNickname"
+                
+                // 유저 정보가 있으면
+                self?.goToTabBar()
+                // 없으면
+                // self?.goToSignUpNickName()
+            },onError: { err in
+                let error = err as? BaseError
+                print("error \(error!)")
+                print("err \(err.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+        
+        self.input.appleSigninTrigger
+            .bind {
+                print("appleSigninTrigger")
+            }
+            .disposed(by: disposeBag)
+        
+        self.input.anonymousTrigger
+            .bind {
+                print("anonymousTrigger")
+            }
+            .disposed(by: disposeBag)
     }
 }
 
 extension LoginViewModel: LoginViewModelType {
-    
-    func goToNickname() {
-        delegate.goToNickname()
-    }
-    
     func goToTabBar() {
         delegate.goToTabBar()
+    }
+    func goToNickname() {
+        delegate.goToNickname()
     }
 }

--- a/FindTown/FindTown/Presentation/Common/Flow/AppCoordinator.swift
+++ b/FindTown/FindTown/Presentation/Common/Flow/AppCoordinator.swift
@@ -7,21 +7,43 @@
 
 import UIKit
 import FindTownCore
+import KakaoSDKAuth
+import KakaoSDKUser
 
 public final class AppCoordinator: Coordinator {
     var navigationController: UINavigationController
+    var userDefaults: UserDefaultUtil
     
-    required init(navigationController: UINavigationController) {
+    required init(
+        navigationController: UINavigationController,
+        userDefaults: UserDefaultUtil
+    ) {
         self.navigationController = navigationController
+        self.userDefaults = userDefaults
     }
     
     public func start() {
-        /// kakao, apple 자동로그인 유무 확인
-        goToTabBar()
-//        goToAuth()
+        
+        print("ACCESS_TOKEN \(userDefaults.accessToken)")
+        print("SIGNIN_TYPE \(userDefaults.signinType)")
+        print("SIGNIN_TYPE \(userDefaults.userNickname)")
+        
+        // 자동 로그인
+        if userDefaults.accessToken == "" {
+            // 로그인 필요
+            goToAuth()
+        } else {
+            // 1. server로 부터 유저정보 확인
+            // 2. 유저정보가 있으면 goToTabBar()
+            // 3. 없으면 goToAuth()
+            
+            goToTabBar()
+        }
     }
     
     private func goToAuth() {
+        navigationController.isNavigationBarHidden = true
+        LoginCoordinator(presentationStyle: .push(navigationController: navigationController)).start()
     }
     
     private func goToTabBar() {

--- a/FindTown/FindTown/Presentation/Utils/UserDefaultUtil.swift
+++ b/FindTown/FindTown/Presentation/Utils/UserDefaultUtil.swift
@@ -1,0 +1,54 @@
+//
+//  UserDefaultUtil.swift
+//  FindTown
+//
+//  Created by 김성훈 on 2023/01/10.
+//
+
+import Foundation
+
+struct UserDefaultUtil {
+    
+    private let ACCESS_TOKEN = "ACCESS_TOKEN"
+    private let SIGNIN_TYPE = "SIGNIN_TYPE"
+    private let USER_NICKNAME = "USER_NICKNAME"
+    
+    let instance: UserDefaults
+    
+    init() {
+        instance = UserDefaults.standard
+    }
+    
+    var accessToken: String {
+        get {
+            return self.instance.string(forKey: ACCESS_TOKEN) ?? ""
+        }
+        set {
+            self.instance.set(newValue, forKey: ACCESS_TOKEN)
+        }
+    }
+    
+    var signinType: String {
+        get {
+            return self.instance.string(forKey: SIGNIN_TYPE) ?? ""
+        }
+        set {
+            self.instance.set(newValue, forKey: SIGNIN_TYPE)
+        }
+    }
+
+    var userNickname: String {
+        get {
+            return self.instance.string(forKey: USER_NICKNAME) ?? ""
+        }
+        set {
+            self.instance.set(newValue, forKey: USER_NICKNAME)
+        }
+    }
+    
+    func clear() {
+        self.instance.removeObject(forKey: ACCESS_TOKEN)
+        self.instance.removeObject(forKey: SIGNIN_TYPE)
+        self.instance.removeObject(forKey: USER_NICKNAME)
+    }
+}

--- a/FindTown/FindTown/Resource/Info.plist
+++ b/FindTown/FindTown/Resource/Info.plist
@@ -2,8 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaolink</string>
+		<string>kakaokompassauth</string>
+	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao3550915888f8318c91ce809f133b5fac</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/FindTown/FindTownCore/Sources/FindTownCore/Extensions/Bundle+Extension.swift
+++ b/FindTown/FindTownCore/Sources/FindTownCore/Extensions/Bundle+Extension.swift
@@ -16,4 +16,12 @@ extension Bundle {
         
         return key
     }
+    
+    public var KAKAO_NATIVE_APP_KEY: String {
+        guard let file = self.path(forResource: "APIKeyInfo", ofType: "plist") else { return "" }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["KakaoNativeAppKey"] as? String else { fatalError("KakaoNativeAppKey error") }
+        
+        return key
+    }
 }


### PR DESCRIPTION
## Motivation
- issue number : #42 

## Changes
- 카카오 버튼 색상 변경
- 카카오 SDK SPM 추가
- 카카오 로그인 기본 기능 구현 (서버 연동 x)

## Screen Shots
![ezgif com-gif-maker](https://user-images.githubusercontent.com/50910456/211986192-7d250c7d-b40e-45a9-a149-2e28317d1cf1.gif)

## To Reviewers
- 우선 서버와 연동없이 카카오 로그인 기능입니다. 애플 로그인도 기능은 완성했습니다만.. 서버들어오고 이것저것 추가하고 수정을 많이 해야합니다.. 그전에 먼저 구조나 플로우 부분 한번 피드백을 받고자 올렸습니다..! 😅
- 로직은 3천원 깃헙을 참고했습니다. [SplashViewModel](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/blob/d151099161b569afb56b9a61cb506085fd55dabd/3dollar-in-my-pocket/domain/splash/SplashViewModel.swift) 을 보시면 자동로그인을 validateToken -> validateTokenFromLocal -> validateTokenFromServer -> refreshPushToken 플로우로 확인하더라구요. 시작을 userDefaults.authToken 값으로 확인을 하길래 저도 userDefault를 활용하려 합니다..!!
- 고민인게 SigninManagerProtocol 안에 SigninRequest, SigninType 부분하고 KakaoSigninManager 안에 BaseError 부분을 어디 폴더를 만들어서 어떤 파일로 빼야할 지 혼란이 옵니다... 조언 부탁드립니다 ㅠㅠㅠㅠ 😢 Manager도 좋은 위치있다면 알려주세요!
