### PR TITLE
유저정보 불러오는 에러 수정

### DIFF
--- a/FindTown/FindTown/Data/DataMapping/Reponse/MemberInfomationResponseDTO.swift
+++ b/FindTown/FindTown/Data/DataMapping/Reponse/MemberInfomationResponseDTO.swift
@@ -40,8 +40,8 @@ struct MemberInformationDTO: Response {
     
     struct Location: Response {
         let objectId: Int
-        let admNm: String
         let sidoNm: String
         let sggNm: String
+        let admNm: String
     }
 }

--- a/FindTown/FindTown/Data/DataMapping/Request/MemberSignupDTO.swift
+++ b/FindTown/FindTown/Data/DataMapping/Request/MemberSignupDTO.swift
@@ -15,7 +15,7 @@ struct MemberSignupDTO: Encodable {
     var objectId: Int?
     var resident: ResidentDTO
     var useAgreeYn: Bool
-    var privaxyAgreeYn: Bool
+    var privacyAgreeYn: Bool
 }
 
 struct ResidentDTO: Encodable {

--- a/FindTown/FindTown/Domain/Entities/SingupUserModel.swift
+++ b/FindTown/FindTown/Domain/Entities/SingupUserModel.swift
@@ -15,7 +15,7 @@ struct SignupUserModel {
     var objectId: Int?
     var resident: Resident
     var useAgreeYn: Bool
-    var privaxyAgreeYn: Bool
+    var privacyAgreeYn: Bool
     
     init(memberId: String = "",
          email: String? = nil,
@@ -24,7 +24,7 @@ struct SignupUserModel {
          objectId: Int? = nil,
          resident: Resident = Resident(),
          useAgreeYn: Bool = false,
-         privaxyAgreeYn: Bool = false
+         privacyAgreeYn: Bool = false
     ) {
         self.memberId = memberId
         self.email = email
@@ -33,7 +33,7 @@ struct SignupUserModel {
         self.objectId = objectId
         self.resident = resident
         self.useAgreeYn = useAgreeYn
-        self.privaxyAgreeYn = privaxyAgreeYn
+        self.privacyAgreeYn = privacyAgreeYn
     }
     
     func toData() -> MemberSignupDTO {
@@ -44,7 +44,7 @@ struct SignupUserModel {
                                objectId: objectId,
                                resident: resident.toData(),
                                useAgreeYn: useAgreeYn,
-                               privaxyAgreeYn: privaxyAgreeYn)
+                               privacyAgreeYn: privacyAgreeYn)
     }
 }
 

--- a/FindTown/FindTown/Presentation/AuthScene/Signup/AgreePolicy/AgreePolicyViewModel.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Signup/AgreePolicy/AgreePolicyViewModel.swift
@@ -80,7 +80,7 @@ final class AgreePolicyViewModel: BaseViewModel {
         Observable.combineLatest(input.policy, input.personalInfo)
             .map { [weak self] (policy, personalInfo) in
                 self?.signupUserModel.useAgreeYn = policy
-                self?.signupUserModel.privaxyAgreeYn = personalInfo
+                self?.signupUserModel.privacyAgreeYn = personalInfo
                 return policy && personalInfo
             }
             .bind { [weak self] isEnabled in


### PR DESCRIPTION
## Motivation
- issue number : #50 

## Changes
- member response에 privaxy -> privacy 오타 수정
- 마이페이지 에러 추가 및 수정

## Screen Shots

![Simulator Screen Recording - iPhone 14 - 2023-02-17 at 15 34 57](https://user-images.githubusercontent.com/50910456/219567640-c2c97551-d82c-4359-b4b6-0325b6ddc134.gif)

## To Reviewers
- MemberInformationDTO에 privaxyAgreeYn 오타 수정했습니다!! 😅
- 마이페이지에서 유저정보 불러올 때 에러가나면 기존에는 아무화면도 안보였는데 "닉네임", "거주 ・ 년 개월" 값을 넘겨주고 화면을 보이도록 수정했습니다! (문의사항이나 제안하기 요런 기능은 사용할 수 있도록)

> 무슨 에러인지는 확인 했는데 거주지 정보 삭제때 그 전 데이터 쌓인걸 삭제 안해줘도 발생했던 에러였어요
- 라고 지훈님께서 말씀하셨습니다..! 이따 퇴근하시고 수정해서 올려두신다고 합니다!! 😀