### PR TITLE
2차 오픈 전 수정 및 개선

### DIFF
--- a/FindTown/FindTown.xcodeproj/project.pbxproj
+++ b/FindTown/FindTown.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B08B1902A1B28FE00955E69 /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2B08B18F2A1B28FE00955E69 /* APIKeyInfo.plist */; };
 		2B42E970299F83DB0093FB0A /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42E96F299F83DB0093FB0A /* UserDefaultsWrapper.swift */; };
 		2B42E972299F85200093FB0A /* UserDefaultsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42E971299F85200093FB0A /* UserDefaultsSetting.swift */; };
 		2B42E986299FCC110093FB0A /* TownIntroduceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42E985299FCC110093FB0A /* TownIntroduceRequest.swift */; };
@@ -199,7 +200,6 @@
 		F3918472299D3F0600CEF02E /* ResignRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3918471299D3F0600CEF02E /* ResignRequest.swift */; };
 		F3918476299E8B9700CEF02E /* MapThemaStoreResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3918475299E8B9700CEF02E /* MapThemaStoreResponseDTO.swift */; };
 		F3918478299E8CB500CEF02E /* ThemaStoreRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3918477299E8CB500CEF02E /* ThemaStoreRequest.swift */; };
-		F3984A7129A92853003FA0C8 /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F3984A7029A92853003FA0C8 /* APIKeyInfo.plist */; };
 		F3984A7429ACBE03003FA0C8 /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3984A7329ACBE03003FA0C8 /* AppDIContainer.swift */; };
 		F3984A7C29ADA30F003FA0C8 /* NetwokDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3984A7B29ADA30F003FA0C8 /* NetwokDIContainer.swift */; };
 		F3984AA529ADAD45003FA0C8 /* AppleAuthRespository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3984AA429ADAD45003FA0C8 /* AppleAuthRespository.swift */; };
@@ -234,6 +234,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2B08B18F2A1B28FE00955E69 /* APIKeyInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKeyInfo.plist; path = ../../../../../APIKeyInfo.plist; sourceTree = "<group>"; };
 		2B42E96F299F83DB0093FB0A /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		2B42E971299F85200093FB0A /* UserDefaultsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsSetting.swift; sourceTree = "<group>"; };
 		2B42E985299FCC110093FB0A /* TownIntroduceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TownIntroduceRequest.swift; sourceTree = "<group>"; };
@@ -424,7 +425,6 @@
 		F3918471299D3F0600CEF02E /* ResignRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignRequest.swift; sourceTree = "<group>"; };
 		F3918475299E8B9700CEF02E /* MapThemaStoreResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapThemaStoreResponseDTO.swift; sourceTree = "<group>"; };
 		F3918477299E8CB500CEF02E /* ThemaStoreRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemaStoreRequest.swift; sourceTree = "<group>"; };
-		F3984A7029A92853003FA0C8 /* APIKeyInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKeyInfo.plist; path = ../../../../../Downloads/APIKeyInfo.plist; sourceTree = "<group>"; };
 		F3984A7329ACBE03003FA0C8 /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
 		F3984A7B29ADA30F003FA0C8 /* NetwokDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetwokDIContainer.swift; sourceTree = "<group>"; };
 		F3984AA429ADAD45003FA0C8 /* AppleAuthRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthRespository.swift; sourceTree = "<group>"; };
@@ -786,7 +786,7 @@
 			isa = PBXGroup;
 			children = (
 				F3891E2A293B8394003CE8AD /* Assets.xcassets */,
-				F3984A7029A92853003FA0C8 /* APIKeyInfo.plist */,
+				2B08B18F2A1B28FE00955E69 /* APIKeyInfo.plist */,
 				F3891E2F293B8394003CE8AD /* Info.plist */,
 				F3891E2C293B8394003CE8AD /* LaunchScreen.storyboard */,
 			);
@@ -1505,7 +1505,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3891E2E293B8394003CE8AD /* LaunchScreen.storyboard in Resources */,
-				F3984A7129A92853003FA0C8 /* APIKeyInfo.plist in Resources */,
+				2B08B1902A1B28FE00955E69 /* APIKeyInfo.plist in Resources */,
 				F3891E2B293B8394003CE8AD /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FindTown/FindTown/Data/DataMapping/Reponse/FavoriteListResponseDTO.swift
+++ b/FindTown/FindTown/Data/DataMapping/Reponse/FavoriteListResponseDTO.swift
@@ -16,14 +16,14 @@ struct FavoriteListResponseDTO: Response {
         for townList in townList {
             let county = CityCode(rawValue: townList.objectId)?.village.rawValue ?? ""
             let countyIcon = CityCode(rawValue: townList.objectId)?.countyIcon ?? UIImage()
-            let townIntroduction = townList.townExplanation
             
             let tableModel = TownTableModel(objectId: townList.objectId,
                                             county: county,
                                             countyIcon: countyIcon,
                                             wishTown: true,
                                             safetyRate: Double(0.0),
-                                            townIntroduction: townIntroduction)
+                                            moods: townList.convertTownMood,
+                                            townFullTitle: townList.convertFullTitle)
             tableModels.append(tableModel)
         }
         return tableModels
@@ -33,5 +33,22 @@ struct FavoriteListResponseDTO: Response {
 struct FavoriteList: Response {
     
     let objectId: Int
-    let townExplanation: String
+    let moods: [String]
+    
+    var convertTownMood: [TownMood] {
+        var townMoodArray: [TownMood] = []
+        
+        for mood in moods {
+            if let mood = TownMood.returnTrafficType(mood) {
+                townMoodArray.append(mood)
+            }
+        }
+        return townMoodArray
+    }
+    
+    var convertFullTitle: String {
+        guard let city = CityCode.init(rawValue: objectId) else { return "" }
+        let townTitle = City(county: city.county, village: city.village).description
+        return townTitle
+    }
 }

--- a/FindTown/FindTown/Data/DataMapping/Reponse/TownFilterResponseDTO.swift
+++ b/FindTown/FindTown/Data/DataMapping/Reponse/TownFilterResponseDTO.swift
@@ -22,26 +22,45 @@ struct TownFilterResponseDTO: Response {
             let countyIcon = CityCode(rawValue: townInformation.objectId)?.countyIcon ?? UIImage()
             let wishTown = townInformation.wishTown
             let safetyRate = townInformation.safetyRate
-            let townIntroduction = townInformation.townIntroduction
+            
             let tableModel = TownTableModel(objectId: townInformation.objectId,
                                             county: county,
                                             countyIcon: countyIcon,
                                             wishTown: wishTown,
                                             safetyRate: safetyRate,
-                                            townIntroduction: townIntroduction)
+                                            moods: townInformation.convertTownMood,
+                                            townFullTitle: townInformation.convertFullTitle)
             tableModels.append(tableModel)
         }
         return tableModels
     }
+
 }
 
 struct TownFilterInformationDTO: Response {
     let objectId: Int
-    let townIntroduction: String
+    let moods: [String]
     let safetyRate: Double
     let lifeRate: Int
     let crimeRate: Int
     let trafficRate: Int
     let reliefYn: String
     let wishTown: Bool
+    
+    var convertTownMood: [TownMood] {
+        var townMoodArray: [TownMood] = []
+        
+        for mood in moods {
+            if let mood = TownMood.returnTrafficType(mood) {
+                townMoodArray.append(mood)
+            }
+        }
+        return townMoodArray
+    }
+    
+    var convertFullTitle: String {
+        guard let city = CityCode.init(rawValue: objectId) else { return "" }
+        let townTitle = City(county: city.county, village: city.village).description
+        return townTitle
+    }
 }

--- a/FindTown/FindTown/Data/DataMapping/Reponse/TownIntroduceResponseDTO.swift
+++ b/FindTown/FindTown/Data/DataMapping/Reponse/TownIntroduceResponseDTO.swift
@@ -84,14 +84,13 @@ struct TownIntroduceDTO: Response {
         let popular = popularGeneration == 0 ? nil : ["\(popularGeneration)대 1인가구",
                                                       "\(popularTownRate)"]
         
-        let townRankData = TownRankData(lifeRank: lifeRate,
-                                        crimeRank: crimeRate,
-                                        trafficRank: trafficRate,
-                                        liveRank: liveRank == 0 ? nil : liveRank,
+        let townRankData = TownRankData(liveRank: liveRank == 0 ? nil : liveRank,
                                         popular: popular,
                                         cleanRank: cleanlinessRank == "N" ? nil : cleanlinessRank,
-                                        safety: reliefYn == "Y" ? "안심보안관 활동지" : nil)
-        
+                                        safety: reliefYn == "Y" ? "안심보안관 활동지" : nil,
+                                        lifeRank: lifeRate,
+                                        crimeRank: crimeRate,
+                                        trafficRank: trafficRate)
         return townRankData.toArray()
     }
 }

--- a/FindTown/FindTown/Data/DataMapping/Reponse/TownSearchResponseDTO.swift
+++ b/FindTown/FindTown/Data/DataMapping/Reponse/TownSearchResponseDTO.swift
@@ -22,13 +22,13 @@ struct TownSearchResponseDTO: Response {
             let countyIcon = CityCode(rawValue: townInformation.objectId)?.countyIcon ?? UIImage()
             let wishTown = townInformation.wishTown
             let safetyRate = 0.0
-            let townIntroduction = townInformation.townIntroduction
             let tableModel = TownTableModel(objectId: townInformation.objectId,
                                             county: county,
                                             countyIcon: countyIcon,
                                             wishTown: wishTown,
                                             safetyRate: safetyRate,
-                                            townIntroduction: townIntroduction)
+                                            moods: townInformation.convertTownMood,
+                                            townFullTitle: townInformation.convertFullTitle)
             tableModels.append(tableModel)
         }
         return tableModels
@@ -37,6 +37,23 @@ struct TownSearchResponseDTO: Response {
 
 struct TownSearchInformationDTO: Response {
     let objectId: Int
-    let townIntroduction: String
+    let moods: [String]
     let wishTown: Bool
+    
+    var convertTownMood: [TownMood] {
+        var townMoodArray: [TownMood] = []
+        
+        for mood in moods {
+            if let mood = TownMood.returnTrafficType(mood) {
+                townMoodArray.append(mood)
+            }
+        }
+        return townMoodArray
+    }
+    
+    var convertFullTitle: String {
+        guard let city = CityCode.init(rawValue: objectId) else { return "" }
+        let townTitle = City(county: city.county, village: city.village).description
+        return townTitle
+    }
 }

--- a/FindTown/FindTown/Domain/Entities/TownTableModel.swift
+++ b/FindTown/FindTown/Domain/Entities/TownTableModel.swift
@@ -13,5 +13,6 @@ struct TownTableModel {
     let countyIcon: UIImage
     var wishTown: Bool
     let safetyRate: Double
-    let townIntroduction: String
+    let moods: [TownMood]
+    let townFullTitle: String
 }

--- a/FindTown/FindTown/Domain/Enumerations/TownRank.swift
+++ b/FindTown/FindTown/Domain/Enumerations/TownRank.swift
@@ -61,13 +61,13 @@ enum TownRank: String, CaseIterable {
 }
 
 struct TownRankData {
-    var lifeRank: Int
-    var crimeRank: Int
-    var trafficRank: Int
     var liveRank: Int?
     var popular: [String]?
     var cleanRank: String?
     var safety: String?
+    var lifeRank: Int
+    var crimeRank: Int
+    var trafficRank: Int
     
     func toArray() -> [(TownRank, Any)] {
         var array = [(TownRank, Any)]()

--- a/FindTown/FindTown/Presentation/AuthScene/Signup/TownMood/TownMoodViewController.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Signup/TownMood/TownMoodViewController.swift
@@ -18,8 +18,8 @@ final class TownMoodViewController: BaseViewController {
     
     private let viewModel: TownMoodViewModel?
     private var keyHeight: CGFloat?
-    private let textViewPlaceHolder = "동네의 장, 단점 or 동네 생활 꿀팁을 알려주세요. \n(최소 20자 이상 작성)"
-    private let afterTwentyTitleText = "최소 20자 이상 작성해주세요"
+    private let textViewPlaceHolder = "동네의 장, 단점 or 동네 생활 꿀팁을 알려주세요. \n(최소 10자 이상 작성)"
+    private let afterTwentyTitleText = "최소 10자 이상 작성해주세요"
     
     // MARK: - Views
     
@@ -35,7 +35,7 @@ final class TownMoodViewController: BaseViewController {
     
     private let afterTwentyTitle = FindTownLabel(text: "", font: .label3, textColor: .error)
     
-    private let textViewCountTitle = FindTownLabel(text: "0/200", font: .label3)
+    private let textViewCountTitle = FindTownLabel(text: "0/100", font: .label3)
     
     private let textViewGuideTitleStackView: UIStackView = {
         let stackView = UIStackView()
@@ -221,9 +221,9 @@ extension TownMoodViewController: UITextViewDelegate {
         let currentText = textViewText
         guard let stringRange = Range(range, in: currentText) else { return false }
         let changedText = currentText.replacingCharacters(in: stringRange, with: text)
-        textViewCountTitle.text = "\(changedText.count)/200"
+        textViewCountTitle.text = "\(changedText.count)/100"
         
-        return changedText.count < 200
+        return changedText.count < 100
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/FindTown/FindTown/Presentation/AuthScene/Signup/TownMood/TownMoodViewModel.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Signup/TownMood/TownMoodViewModel.swift
@@ -51,7 +51,7 @@ final class TownMoodViewModel: BaseViewModel {
         
         self.input.townLikeText
             .bind { [weak self] inputText in
-                self?.output.buttonsSelected.accept(inputText.count < 20 ? false : true)
+                self?.output.buttonsSelected.accept(inputText.count < 10 ? false : true)
             }
             .disposed(by: disposeBag)
     }

--- a/FindTown/FindTown/Presentation/FavoriteScene/Favorite/FavoriteViewModel.swift
+++ b/FindTown/FindTown/Presentation/FavoriteScene/Favorite/FavoriteViewModel.swift
@@ -39,6 +39,7 @@ final class FavoriteViewModel: BaseViewModel {
         let townIntroButtonTrigger = PublishSubject<Int>()
         let townMapButtonTrigger = PublishSubject<Int>()
         let favoriteButtonTrigger = PublishSubject<Int>()
+        let refreshTrigger = PublishSubject<Void>()
     }
     
     struct Output {
@@ -101,6 +102,12 @@ final class FavoriteViewModel: BaseViewModel {
                 self?.delegate.goToTownMap(cityCode: cityCode)
             })
             .disposed(by: disposeBag)
+        
+        self.input.refreshTrigger
+            .subscribe(onNext: { [weak self] in
+                self?.getFavoriteList()
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -156,7 +163,6 @@ extension FavoriteViewModel {
                 let favoriteStatus = try await self.memberUseCase.favorite(accessToken: accessToken,
                                                                            cityCode: cityCode)
                 await MainActor.run(body: {
-                    self.getFavoriteList()
                     self.output.isFavorite.onNext(favoriteStatus)
                 })
             } catch (let error) {

--- a/FindTown/FindTown/Presentation/FavoriteScene/Favorite/SubViews/FavoriteTableView.swift
+++ b/FindTown/FindTown/Presentation/FavoriteScene/Favorite/SubViews/FavoriteTableView.swift
@@ -31,7 +31,7 @@ private extension FavoriteTableView {
         self.backgroundColor = .clear
         self.showsVerticalScrollIndicator = false
         self.automaticallyAdjustsScrollIndicatorInsets = false
-        self.rowHeight = 142 + 16
+        self.rowHeight = 174 + 16
         self.tableHeaderView = returnTableHeaderView()
         self.register(TownTableViewCell.self,
                       forCellReuseIdentifier: TownTableViewCell.reuseIdentifier)

--- a/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewController.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewController.swift
@@ -472,7 +472,7 @@ extension HomeViewController: TownTableFooterViewDelegate {
 
 extension HomeViewController: HomeFavoriteDelegate {
     func HomeFavoriteFetch(_ cityCode: Int) {
-        self.viewModel?.input.favoriteButtonTrigger.onNext(cityCode)
+        self.viewModel?.input.changeFavoriteStatus.onNext(cityCode)
     }
 }
 

--- a/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewController.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewController.swift
@@ -242,8 +242,6 @@ final class HomeViewController: BaseViewController {
         
         townTableView.tableFooterView?.isHidden = true
         townTableView.isHidden = true
-        townTableView.rowHeight = 150
-        townTableView.estimatedRowHeight = 150
         
         safetyToolTip.dismiss()
         addTapGesture()

--- a/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewController.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewController.swift
@@ -358,9 +358,8 @@ final class HomeViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         viewModel?.output.isFavorite
-            .filter { $0 == false }
-            .subscribe(onNext: { [weak self] _ in
-                let toastMessage = "찜 목록에서 삭제되었어요"
+            .subscribe(onNext: { [weak self] isFavorite in
+                let toastMessage = isFavorite ? "찜 목록에 추가되었어요" : "찜 목록에서 삭제되었어요"
                 self?.showToast(message: toastMessage, height: 120)
             })
             .disposed(by: disposeBag)

--- a/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewModel.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/HomeViewModel.swift
@@ -42,6 +42,7 @@ final class HomeViewModel: BaseViewModel {
         let townMapButtonTrigger = PublishSubject<Int>()
         let favoriteButtonTrigger = PublishSubject<Int>()
         let goToAuthButtonTrigger = PublishSubject<Void>()
+        let changeFavoriteStatus = PublishSubject<Int>()
     }
     
     struct Output {
@@ -140,6 +141,12 @@ final class HomeViewModel: BaseViewModel {
                 self?.goToAuth()
             })
             .disposed(by: disposeBag)
+        
+        self.input.changeFavoriteStatus
+            .subscribe(onNext: { [weak self] cityCode in
+                self?.changeFavoriteStatus(cityCode)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -207,6 +214,17 @@ extension HomeViewModel {
                 Log.error(error)
             }
         }
+    }
+}
+
+extension HomeViewModel {
+    
+    func changeFavoriteStatus(_ cityCode: Int) {
+        var dataSource = self.output.searchTownTableDataSource.value
+        let index = dataSource.indices.filter({ dataSource[$0].objectId == cityCode }).first
+        guard let index = index else { return }
+        dataSource[index].wishTown = !dataSource[index].wishTown
+        self.output.searchTownTableDataSource.accept(dataSource)
     }
 }
 

--- a/FindTown/FindTown/Presentation/HomeScene/Home/SubViews/TownTableView.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/SubViews/TownTableView.swift
@@ -26,5 +26,6 @@ final class TownTableView: UITableView {
         backgroundColor = FindTownColor.white.color
         separatorStyle = .none
         register(TownTableViewCell.self, forCellReuseIdentifier: TownTableViewCell.reuseIdentifier)
+        self.rowHeight = 174 + 16
     }
 }

--- a/FindTown/FindTown/Presentation/HomeScene/Home/SubViews/TownTableViewCell.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/SubViews/TownTableViewCell.swift
@@ -40,10 +40,9 @@ final class TownTableViewCell: UITableViewCell {
     
     // MARK: Views
     
-    private let townIconView = UIView()
-    private let townIconImageView = UIImageView()
-    private let townTitle = FindTownLabel(text: "", font: .subtitle4)
-    private let townIntroduceTitle = FindTownLabel(text: "", font: .body3, textColor: .grey5)
+    private let townTitle = FindTownLabel(text: "", font: .subtitle2)
+    private let townIntroduceTitle = FindTownLabel(text: "", font: .label2, textColor: .grey5)
+    private let townMoodCollectionView = TownMoodCollectionView()
     
     private let favoriteIcon: UIButton = {
         let button = UIButton()
@@ -96,41 +95,36 @@ final class TownTableViewCell: UITableViewCell {
             buttonStackView.addArrangedSubview($0)
         }
         
-        [townIconView, townTitle, townIntroduceTitle, favoriteIcon, buttonStackView].forEach {
+        [townMoodCollectionView, townTitle, townIntroduceTitle, favoriteIcon, buttonStackView].forEach {
             contentView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
-        
-        townIconView.addSubview(townIconImageView)
-        townIconImageView.translatesAutoresizingMaskIntoConstraints = false
     }
     
     private func setLayout() {
         NSLayoutConstraint.activate([
-            townIconView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
-            townIconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            townIconView.widthAnchor.constraint(equalToConstant: 48),
-            townIconView.heightAnchor.constraint(equalToConstant: 48),
-            townIconImageView.centerXAnchor.constraint(equalTo: townIconView.centerXAnchor),
-            townIconImageView.centerYAnchor.constraint(equalTo: townIconView.centerYAnchor)
+            townMoodCollectionView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            townMoodCollectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            townMoodCollectionView.trailingAnchor.constraint(equalTo: favoriteIcon.leadingAnchor, constant: -16),
+            townMoodCollectionView.heightAnchor.constraint(equalToConstant: 35.0)
         ])
         
         NSLayoutConstraint.activate([
-            townTitle.topAnchor.constraint(equalTo: townIconView.topAnchor),
-            townTitle.leadingAnchor.constraint(equalTo: townIconView.trailingAnchor, constant: 16),
-            townIntroduceTitle.topAnchor.constraint(equalTo: townTitle.bottomAnchor, constant: 4),
-            townIntroduceTitle.leadingAnchor.constraint(equalTo: townTitle.leadingAnchor)
+            townTitle.topAnchor.constraint(equalTo: townMoodCollectionView.bottomAnchor, constant: 16),
+            townTitle.leadingAnchor.constraint(equalTo: townMoodCollectionView.leadingAnchor),
+            townIntroduceTitle.centerYAnchor.constraint(equalTo: townTitle.centerYAnchor),
+            townIntroduceTitle.leadingAnchor.constraint(equalTo: townTitle.trailingAnchor, constant: 8.0)
         ])
         
         NSLayoutConstraint.activate([
-            favoriteIcon.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 14),
-            favoriteIcon.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -14),
+            favoriteIcon.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            favoriteIcon.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             favoriteIcon.widthAnchor.constraint(equalToConstant: 24),
             favoriteIcon.heightAnchor.constraint(equalToConstant: 24)
         ])
         
         NSLayoutConstraint.activate([
-            buttonStackView.topAnchor.constraint(equalTo: townIntroduceTitle.bottomAnchor, constant: 16),
+            buttonStackView.topAnchor.constraint(equalTo: townTitle.bottomAnchor, constant: 22),
             buttonStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             buttonStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             buttonStackView.heightAnchor.constraint(equalToConstant: 44),
@@ -140,12 +134,7 @@ final class TownTableViewCell: UITableViewCell {
     
     private func setupView() {
         self.backgroundColor = FindTownColor.back2.color
-        
-        townIconView.backgroundColor = FindTownColor.white.color
-        townIconView.layer.cornerRadius = 24
-        townIconView.layer.borderWidth = 1.0
-        townIconView.layer.borderColor = FindTownColor.grey3.color.cgColor
-        townIconImageView.image = UIImage(named: "hospital")
+        self.selectionStyle = .none
         
         mapButton.changesSelectionAsPrimaryAction = false
         mapButton.isSelected = true
@@ -158,8 +147,7 @@ final class TownTableViewCell: UITableViewCell {
         contentView.layer.addCustomShadow(shadowX: 0, shadowY: 2,
                                           shadowColor: FindTownColor.black.color.withAlphaComponent(0.4),
                                           blur: 10.0, spread: 0, alpha: 0.4)
-        
-        selectionStyle = .none
+    
         
         introduceButton.addTarget(self, action: #selector(didTapGoToIntroduceButton), for: .touchUpInside)
         mapButton.addTarget(self, action: #selector(didTapGoToMapButton), for: .touchUpInside)
@@ -172,6 +160,13 @@ final class TownTableViewCell: UITableViewCell {
                 self?.didTapFavoriteButton()
             }
             .disposed(by: disposeBag)
+        
+        // TODO: API 수정되면 수정 필요
+        BehaviorSubject<[TownMood]>(value: [.infra1, .mood4])
+            .bind(to: townMoodCollectionView.rx.items(cellIdentifier: TownMoodCollectionViewCell.reuseIdentifier, cellType: TownMoodCollectionViewCell.self)) { index, item, cell in
+                cell.setupCell(item)
+            }
+            .disposed(by: disposeBag)
     }
     
     func setupCell(_ model: Any, cityCode: Int) {
@@ -182,7 +177,6 @@ final class TownTableViewCell: UITableViewCell {
         favoriteIcon.isSelected = model.wishTown ? true : false
         townTitle.text = model.county
         townIntroduceTitle.text = model.townIntroduction
-        townIconImageView.image = model.countyIcon
         favoriteIcon.isSelected = model.wishTown ? true : false
     }
 }

--- a/FindTown/FindTown/Presentation/SearchScene/Search/ShowVillageList/ShowVillageListViewController.swift
+++ b/FindTown/FindTown/Presentation/SearchScene/Search/ShowVillageList/ShowVillageListViewController.swift
@@ -120,12 +120,11 @@ final class ShowVillageListViewController: BaseViewController {
                 self?.townCountTitle.text = "\(searchTown.count)개 동네"
             }
             .disposed(by: disposeBag)
-        
+    
         viewModel?.output.isFavorite
-            .filter { $0 == false }
-            .subscribe(onNext: { [weak self] _ in
-                let toastMessage = "찜 목록에서 삭제되었어요"
-                self?.showToast(message: toastMessage, height: 60)
+            .subscribe(onNext: { [weak self] isFavorite in
+                let toastMessage = isFavorite ? "찜 목록에 추가되었어요" : "찜 목록에서 삭제되었어요"
+                self?.showToast(message: toastMessage, height: 120)
             })
             .disposed(by: disposeBag)
         

--- a/FindTown/FindTown/Presentation/SearchScene/Search/ShowVillageList/ShowVillageListViewController.swift
+++ b/FindTown/FindTown/Presentation/SearchScene/Search/ShowVillageList/ShowVillageListViewController.swift
@@ -92,9 +92,6 @@ final class ShowVillageListViewController: BaseViewController {
         guard let selectCountyData = self.viewModel?.selectCountyData else { return }
         selectCountyTitle.text = "서울시 \(selectCountyData)"
         
-        townTableView.rowHeight = 150
-        townTableView.estimatedRowHeight = 150
-        
         viewModel?.fetchTownInformation()
     }
     


### PR DESCRIPTION
## Motivation
- issue number : #100 

## Changes
- 찜 탭 activity indicator 추가
   - 홈 탭의 찜 여부 반영되는 로직 수정
- 동네 카드 UI 수정(홈, 검색, 찜 화면에 반영됨)
- 동네후기 글자수 제한 변경
- 동네 소개 - 숫자로 보는 동네 카드 순서 변경

## Screen Shots
<img src = "https://github.com/YAPP-Github/21st-iOS-Team-1-iOS/assets/77603632/dec48990-81be-4dbc-bbe6-86e82374844d" width="300" height="600">  


## To Reviewers
- 동네 카드 UI만 우선 수정해놓고 추후에 api 수정되면 다시 수정하도록 할게요!