### PR TITLE
키보드 로직 수정

### DIFF
--- a/FindTown/FindTown/Presentation/AuthScene/Signup/Nickname/NicknameViewController.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Signup/Nickname/NicknameViewController.swift
@@ -57,12 +57,12 @@ final class NicknameViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        keyboardNotificationInit()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        keyboardNotificationDeInit()
+        
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -16),
+            nextButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            nextButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+        ])
     }
     
     // MARK: - Functions
@@ -109,10 +109,11 @@ final class NicknameViewController: BaseViewController {
         ])
         
         NSLayoutConstraint.activate([
-            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            nextButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -16),
             nextButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             nextButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
         ])
+        
     }
     
     override func setupView() {
@@ -215,37 +216,6 @@ final class NicknameViewController: BaseViewController {
     private func buttonStatusChange(_ isStatus: Bool) {
         duplicateButton.isEnabledAndSelected(isStatus)
         nextButton.isEnabledAndSelected(!isStatus)
-    }
-    
-    @objc private func keyboardWillShowSender(_ sender: Notification) {
-        let userInfo:NSDictionary = sender.userInfo! as NSDictionary
-        let keyboardFrame:NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as! NSValue
-        let keyboardRectangle = keyboardFrame.cgRectValue
-        let keyboardHeight = keyboardRectangle.height
-        keyHeight = keyboardHeight
-        
-        self.view.frame.size.height -= keyboardHeight
-        
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-    }
-    
-    @objc private func keyboardWillHideSender(_ sender: Notification) {
-        guard let keyHeight = keyHeight else { return }
-        self.view.frame.size.height += keyHeight
-        
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        keyboardNotificationInit()
-    }
-    
-    private func keyboardNotificationInit() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShowSender(_:)),
-                                               name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHideSender(_:)),
-                                               name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    private func keyboardNotificationDeInit() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 }
 

--- a/FindTown/FindTown/Presentation/AuthScene/Signup/TownMood/TownMoodViewController.swift
+++ b/FindTown/FindTown/Presentation/AuthScene/Signup/TownMood/TownMoodViewController.swift
@@ -64,12 +64,12 @@ final class TownMoodViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        keyboardNotificationInit()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        keyboardNotificationDeInit()
+        
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -16),
+            nextButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            nextButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+        ])
     }
     
     // MARK: - Functions
@@ -112,7 +112,7 @@ final class TownMoodViewController: BaseViewController {
         ])
         
         NSLayoutConstraint.activate([
-            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            nextButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -16),
             nextButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             nextButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
         ])
@@ -180,37 +180,6 @@ final class TownMoodViewController: BaseViewController {
             nextButton.isEnabled = isSelected
         }
         afterTwentyTitle.text = isSelected ? "" : afterTwentyTitleText
-    }
-    
-    @objc private func keyboardWillShowSender(_ sender: Notification) {
-        let userInfo:NSDictionary = sender.userInfo! as NSDictionary
-        let keyboardFrame:NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as! NSValue
-        let keyboardRectangle = keyboardFrame.cgRectValue
-        let keyboardHeight = keyboardRectangle.height
-        keyHeight = keyboardHeight
-        
-        self.view.frame.size.height -= keyboardHeight
-        
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-    }
-    
-    @objc private func keyboardWillHideSender(_ sender: Notification) {
-        guard let keyHeight = keyHeight else { return }
-        self.view.frame.size.height += keyHeight
-        
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        keyboardNotificationInit()
-    }
-    
-    private func keyboardNotificationInit() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShowSender(_:)),
-                                               name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHideSender(_:)),
-                                               name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    private func keyboardNotificationDeInit() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 }
 

--- a/FindTown/FindTown/Presentation/MyPageScene/MyPage/ChangeNickname/ChangeNicknameViewController.swift
+++ b/FindTown/FindTown/Presentation/MyPageScene/MyPage/ChangeNickname/ChangeNicknameViewController.swift
@@ -53,13 +53,14 @@ final class ChangeNicknameViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        keyboardNotificationInit()
+        
+        NSLayoutConstraint.activate([
+            confirmButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -16),
+            confirmButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            confirmButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+        ])
     }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        keyboardNotificationDeInit()
-    }
+
     
     // MARK: - Functions
     
@@ -207,37 +208,6 @@ final class ChangeNicknameViewController: BaseViewController {
     private func buttonStatusChange(_ isStatus: Bool) {
         duplicateButton.isEnabledAndSelected(isStatus)
         confirmButton.isEnabledAndSelected(!isStatus)
-    }
-    
-    @objc private func keyboardWillShowSender(_ sender: Notification) {
-        let userInfo:NSDictionary = sender.userInfo! as NSDictionary
-        let keyboardFrame:NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as! NSValue
-        let keyboardRectangle = keyboardFrame.cgRectValue
-        let keyboardHeight = keyboardRectangle.height
-        keyHeight = keyboardHeight
-        
-        self.view.frame.size.height -= keyboardHeight
-        
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-    }
-    
-    @objc private func keyboardWillHideSender(_ sender: Notification) {
-        guard let keyHeight = keyHeight else { return }
-        self.view.frame.size.height += keyHeight
-        
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        keyboardNotificationInit()
-    }
-    
-    private func keyboardNotificationInit() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShowSender(_:)),
-                                               name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHideSender(_:)),
-                                               name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    private func keyboardNotificationDeInit() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 }
 


### PR DESCRIPTION
## Motivation
- issue number : #100

## Changes
- 닉네임, 동네분위기, 닉네임 수정 화면 키보드 로직 수정


## Screen Shots
- ![Simulator Screen Shot - iPhone 13 - 2023-06-18 at 19 08 15](https://github.com/YAPP-Github/21st-iOS-Team-1-iOS/assets/77603632/9a4bde8c-e8f9-4acb-8925-94501dfeaad4)

## To Reviewers
-  한 가지.. 이슈가 있는데요 ㅠㅠ 네비게이션 스택에서 dismiss 하는 경우 keyboardlayoutguide와 관련된 레이아웃이 깨집니다 🥹
제일 간단한 해결 방법이 viewwillappear에서 버튼의 레이아웃을 다시 한번 설정해주는거라고 생각해서 지금처럼 설정했어요..! 더 좋은 방안이 있다면 피드백 부탁드릴게요! 