### PR TITLE
찜 딜레이 추가 & 검색 화면 마진 개선

### DIFF
--- a/FindTown/FindTown.xcodeproj/project.pbxproj
+++ b/FindTown/FindTown.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B3266252A4D77FA00F883B0 /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2B3266242A4D77FA00F883B0 /* APIKeyInfo.plist */; };
 		2B42E970299F83DB0093FB0A /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42E96F299F83DB0093FB0A /* UserDefaultsWrapper.swift */; };
 		2B42E972299F85200093FB0A /* UserDefaultsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42E971299F85200093FB0A /* UserDefaultsSetting.swift */; };
 		2B42E986299FCC110093FB0A /* TownIntroduceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42E985299FCC110093FB0A /* TownIntroduceRequest.swift */; };
@@ -158,7 +159,6 @@
 		F363D160299A1D4600606C7F /* TownMapLocationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363D15F299A1D4600606C7F /* TownMapLocationDTO.swift */; };
 		F363D164299A2E1800606C7F /* VillageLocationInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363D163299A2E1800606C7F /* VillageLocationInformation.swift */; };
 		F363D167299A39D200606C7F /* MapConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363D166299A39D200606C7F /* MapConstant.swift */; };
-		F381193F2A30C92300BFCCB2 /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F381193E2A30C92200BFCCB2 /* APIKeyInfo.plist */; };
 		F38119412A30CA3C00BFCCB2 /* MapInfraIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38119402A30CA3C00BFCCB2 /* MapInfraIconView.swift */; };
 		F38119452A30DE6E00BFCCB2 /* MapThemaIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38119442A30DE6E00BFCCB2 /* MapThemaIconView.swift */; };
 		F3891E1F293B8393003CE8AD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3891E1E293B8393003CE8AD /* AppDelegate.swift */; };
@@ -241,6 +241,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2B3266242A4D77FA00F883B0 /* APIKeyInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKeyInfo.plist; path = ../../../../../APIKeyInfo.plist; sourceTree = "<group>"; };
 		2B42E96F299F83DB0093FB0A /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		2B42E971299F85200093FB0A /* UserDefaultsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsSetting.swift; sourceTree = "<group>"; };
 		2B42E985299FCC110093FB0A /* TownIntroduceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TownIntroduceRequest.swift; sourceTree = "<group>"; };
@@ -385,7 +386,6 @@
 		F363D15F299A1D4600606C7F /* TownMapLocationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TownMapLocationDTO.swift; sourceTree = "<group>"; };
 		F363D163299A2E1800606C7F /* VillageLocationInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VillageLocationInformation.swift; sourceTree = "<group>"; };
 		F363D166299A39D200606C7F /* MapConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapConstant.swift; sourceTree = "<group>"; };
-		F381193E2A30C92200BFCCB2 /* APIKeyInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKeyInfo.plist; path = ../../../../../../../../Downloads/APIKeyInfo.plist; sourceTree = "<group>"; };
 		F38119402A30CA3C00BFCCB2 /* MapInfraIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapInfraIconView.swift; sourceTree = "<group>"; };
 		F38119442A30DE6E00BFCCB2 /* MapThemaIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapThemaIconView.swift; sourceTree = "<group>"; };
 		F3891E1B293B8393003CE8AD /* FindTown.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FindTown.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -801,7 +801,7 @@
 			isa = PBXGroup;
 			children = (
 				F3891E2A293B8394003CE8AD /* Assets.xcassets */,
-				F381193E2A30C92200BFCCB2 /* APIKeyInfo.plist */,
+				2B3266242A4D77FA00F883B0 /* APIKeyInfo.plist */,
 				F3891E2F293B8394003CE8AD /* Info.plist */,
 				F3891E2C293B8394003CE8AD /* LaunchScreen.storyboard */,
 			);
@@ -1535,7 +1535,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3891E2E293B8394003CE8AD /* LaunchScreen.storyboard in Resources */,
-				F381193F2A30C92300BFCCB2 /* APIKeyInfo.plist in Resources */,
+				2B3266252A4D77FA00F883B0 /* APIKeyInfo.plist in Resources */,
 				F3891E2B293B8394003CE8AD /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FindTown/FindTown.xcodeproj/xcuserdata/jsy.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/FindTown/FindTown.xcodeproj/xcuserdata/jsy.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>FindTown.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>Rx (Playground) 1.xcscheme</key>
 		<dict>

--- a/FindTown/FindTown/Presentation/FavoriteScene/Favorite/FavoriteViewController.swift
+++ b/FindTown/FindTown/Presentation/FavoriteScene/Favorite/FavoriteViewController.swift
@@ -107,6 +107,7 @@ final class FavoriteViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         self.refreshControl.rx.controlEvent(.valueChanged)
+            .delay(.seconds(1), scheduler: MainScheduler.instance)
             .bind { [weak self] in
                 self?.viewModel?.input.refreshTrigger.onNext(())
             }

--- a/FindTown/FindTown/Presentation/HomeScene/Home/SubViews/TownTableView.swift
+++ b/FindTown/FindTown/Presentation/HomeScene/Home/SubViews/TownTableView.swift
@@ -23,7 +23,7 @@ final class TownTableView: UITableView {
     
     private func setupView() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = FindTownColor.white.color
+        backgroundColor = FindTownColor.back2.color
         separatorStyle = .none
         register(TownTableViewCell.self, forCellReuseIdentifier: TownTableViewCell.reuseIdentifier)
         self.rowHeight = 174 + 16

--- a/FindTown/FindTown/Presentation/SearchScene/Search/ShowVillageList/ShowVillageListViewController.swift
+++ b/FindTown/FindTown/Presentation/SearchScene/Search/ShowVillageList/ShowVillageListViewController.swift
@@ -33,14 +33,7 @@ final class ShowVillageListViewController: BaseViewController {
     }()
     
     private let townTableView = TownTableView()
-    
-    private let townListBackgroundView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
-    }()
-    
+
     // MARK: - Life Cycle
     
     init(viewModel: ShowVillageListViewModel?) {
@@ -63,22 +56,23 @@ final class ShowVillageListViewController: BaseViewController {
             townListAndCountStackView.addArrangedSubview($0)
         }
         
-        view.addSubview(townTableView)
-        townTableView.tableHeaderView = townListAndCountStackView
+        [townListAndCountStackView, townTableView].forEach {
+            view.addSubview($0)
+        }
     }
     
     override func setLayout() {
-        townListAndCountStackView.layoutMargins = UIEdgeInsets(top: 20, left: 16, bottom: 10, right: 16)
+        townListAndCountStackView.layoutMargins = UIEdgeInsets(top: 20, left: 16, bottom: 16, right: 16)
         townListAndCountStackView.isLayoutMarginsRelativeArrangement = true
         
-        townListAndCountStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
+            townListAndCountStackView.topAnchor.constraint(equalTo: view.topAnchor),
             townListAndCountStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             townListAndCountStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         
         NSLayoutConstraint.activate([
-            townTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            townTableView.topAnchor.constraint(equalTo: townListAndCountStackView.bottomAnchor),
             townTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             townTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             townTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -87,7 +81,7 @@ final class ShowVillageListViewController: BaseViewController {
     
     override func setupView() {
         view.backgroundColor = FindTownColor.white.color
-        townListBackgroundView.backgroundColor = FindTownColor.back2.color
+        townTableView.contentInset = UIEdgeInsets(top: 24 - 8, left: 0, bottom: 0, right: 0)
         
         guard let selectCountyData = self.viewModel?.selectCountyData else { return }
         selectCountyTitle.text = "서울시 \(selectCountyData)"


### PR DESCRIPTION
## Motivation
- issue number : #106 

## Changes
- 찜 activity indicator delay (1초)
- 검색 화면 마진 개선

## Screen Shots
<img src = "https://github.com/YAPP-Github/21st-iOS-Team-1-iOS/assets/77603632/eb2deac5-6f1c-488c-8e8d-e1bbe27957b5" width="250" height="500">

## To Reviewers
검색 화면 상단의 구 이름과 동네 개수를 포함하고 있는 뷰가 tableview 헤더로 들어가 있어 스크롤할 때 함께 스크롤이 되더라구요! 
그래서 분리해서 해당 뷰는 스크롤돼도 상단에 고정되어 있도록 개선했습니당 